### PR TITLE
fix closing of README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,5 @@ $server = new Server(new class ($echo) implements RequestHandler {
 
 $server->listen(8080);
 
-Loop\run();```
+Loop\run();
+```


### PR DESCRIPTION
By having the ``` markup on an existing line, the github web rendering of the code block included the characters.
